### PR TITLE
Guard libpqxx source location macro

### DIFF
--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -54,8 +54,10 @@
 
 #include "lan_mac.hpp"
 #include <argon2.h>
-// put this above the pqxx include:
+// Fix libpqxx ABI mismatch on Ubuntu 24.04 by hiding std::source_location symbols
+#ifndef PQXX_HIDE_SOURCE_LOCATION
 #define PQXX_HIDE_SOURCE_LOCATION
+#endif
 #include <pqxx/pqxx>
 #include <sw/redis++/redis++.h>
 


### PR DESCRIPTION
## Summary
- Guard `PQXX_HIDE_SOURCE_LOCATION` macro to avoid libpqxx ABI mismatch from `std::source_location` symbols.

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_e_68bfa7c508a883308c93379d0aba12c6