### PR TITLE
chore: install nlohmann json dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
       libssl-dev \
       libpq-dev \
       libboost-dev libboost-system-dev libboost-thread-dev \
-      libhiredis-dev && \
+      libhiredis-dev \
+      nlohmann-json3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # ---- Build redis-plus-plus (headers+libs into /usr/local) ------------------


### PR DESCRIPTION
## Summary
- install nlohmann-json3-dev in Docker image to satisfy CMake's find_package

## Testing
- `docker build -t bcord-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbc163a548330aa9310722793881d